### PR TITLE
Add AI Language Partner to Japanese resources

### DIFF
--- a/languages/ja/README.md
+++ b/languages/ja/README.md
@@ -4,3 +4,7 @@ See [Awesome Japanese](https://github.com/yudataguy/Awesome-Japanese) &
 [All Language Resources](https://www.alllanguageresources.com/resources/japanese).
 
 Please file a PR if you'd like to see this page not empty!
+
+## Apps and tools
+
+- [AI Language Partner](https://github.com/duct-tape2/ai-language-partner) - Free, open-source, local-first Japanese dialogue practice app for Korean speakers, with scripted dialogue packs, STT/TTS setup docs, and a hosted mock-mode demo.


### PR DESCRIPTION
Adds AI Language Partner to the currently empty Japanese resource page.

It is a free, open-source, local-first Japanese dialogue practice app for Korean speakers, with scripted dialogue packs and a hosted mock-mode demo, so it fits the page as a language-specific learning app/tool.

Repository: https://github.com/duct-tape2/ai-language-partner
Demo: https://duct-tape2.github.io/ai-language-partner/demo/